### PR TITLE
Change app startup to allow Nancy to send back a large JSON response.

### DIFF
--- a/src/Sitecore.Ship/DefaultBootstrapper.cs
+++ b/src/Sitecore.Ship/DefaultBootstrapper.cs
@@ -17,6 +17,13 @@ namespace Sitecore.Ship
 {
     public class DefaultBootstrapper : DefaultNancyBootstrapper
     {
+        protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
+        {
+            base.ApplicationStartup(container, pipelines);
+
+            Nancy.Json.JsonSettings.MaxJsonLength = int.MaxValue;
+        }
+
         protected override void ConfigureConventions(Nancy.Conventions.NancyConventions nancyConventions)
         {
             base.ConfigureConventions(nancyConventions);


### PR DESCRIPTION
Kevin,
    I ran into an issue using ship where Nancy failed with a JSON too large error when generating the response while installing a Sitecore update package. This fixes the problem.

Charlie
