### PR TITLE
Add the ability to configure item Publish options, such as deep, smart or related items options, when publishing a list of items.

### DIFF
--- a/src/Sitecore.Ship.Core/Domain/ItemsToPublish.cs
+++ b/src/Sitecore.Ship.Core/Domain/ItemsToPublish.cs
@@ -8,5 +8,8 @@ namespace Sitecore.Ship.Core.Domain
         public List<Guid> Items { get; set; }
         public string[] TargetDatabases { get; set; }
         public string[] TargetLanguages { get; set; }
+        public bool SmartPublish { get; set; }
+        public bool DeepPublish { get; set; }
+        public bool PublishRelatedItems { get; set; }
     }
 }

--- a/src/Sitecore.Ship.Core/Domain/ItemsToPublish.cs
+++ b/src/Sitecore.Ship.Core/Domain/ItemsToPublish.cs
@@ -17,6 +17,9 @@ namespace Sitecore.Ship.Core.Domain
 			Items = new List<Guid>();
 			TargetDatabases = new string[] { };
 			TargetLanguages = new string[] { };
+		    SmartPublish = true;
+		    DeepPublish = true;
+		    PublishRelatedItems = false;
 		}
     }
 }

--- a/src/Sitecore.Ship.Infrastructure/PublishService.cs
+++ b/src/Sitecore.Ship.Infrastructure/PublishService.cs
@@ -38,7 +38,7 @@ namespace Sitecore.Ship.Infrastructure
                     var item = master.GetItem(new ID(itemToPublish));
                     if (item != null)
                     {
-                        Publishing.PublishManager.PublishItem(item, itemsToPublish.TargetDatabases.Select(Sitecore.Configuration.Factory.GetDatabase).ToArray(), languages, true, true);
+                        Publishing.PublishManager.PublishItem(item, itemsToPublish.TargetDatabases.Select(Sitecore.Configuration.Factory.GetDatabase).ToArray(), languages, itemsToPublish.DeepPublish, itemsToPublish.SmartPublish, itemsToPublish.PublishRelatedItems);
                     }
                 }
             }


### PR DESCRIPTION
I've extended the "ItemsToPublish" class with three more parameters to control how an item is published: publish subitems (deep), compare revisions (smart) and publish related items or not.

I've added them to the constructor with the same values that are being used now, to keep backwards compatibility. Then, just changed the hardcoded "true" values is method call Publishing.PublishManager.PublishItem(), and added the related items one, that was missing.

This way, the caller can widely control how the items in the list provided are being published.

Hope this helps.
Regards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kevinobee/sitecore.ship/50)
<!-- Reviewable:end -->
