### PR TITLE
BaseHttpHandler no longer continues execution when authorisation fails (fixes #53)

### DIFF
--- a/src/Sitecore.Ship.AspNet/BaseHttpHandler.cs
+++ b/src/Sitecore.Ship.AspNet/BaseHttpHandler.cs
@@ -37,6 +37,7 @@ namespace Sitecore.Ship.AspNet
             if (!_authoriser.IsAllowed())
             {
                 context.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
+                return;
             }
 
             context.Items.Add(StartTime, DateTime.UtcNow);

--- a/tests/unit-test/Sitecore.Ship.AspNet.Test/BaseHttpHandlerUnauthorisedTests.cs
+++ b/tests/unit-test/Sitecore.Ship.AspNet.Test/BaseHttpHandlerUnauthorisedTests.cs
@@ -1,0 +1,60 @@
+﻿using Moq;
+using System.Web;
+using Xunit;
+using System;
+using Should;
+using Sitecore.Ship.Core.Contracts;
+using System.IO;
+
+namespace Sitecore.Ship.AspNet.Test
+{
+    public class BaseHttpHandlerUnauthorisedTests
+    {
+        private HttpResponse _response;
+        private SampleHandler _sut;
+
+        public BaseHttpHandlerUnauthorisedTests()
+        {
+            var authoriser = new Mock<IAuthoriser>();
+            authoriser.Setup(x => x.IsAllowed()).Returns(false);
+
+            var request = new HttpRequest("", "http://tempuri.org", "");
+            _response = new HttpResponse(new StringWriter());
+
+            var context = new HttpContext(request, _response);
+
+            _sut = new SampleHandler(authoriser.Object);
+            _sut.ProcessRequest(context);
+        }
+
+        [Fact]
+        public void ReturnsStatusCodeUnauthorized()
+        {
+            _response.StatusCode.ShouldEqual(401);
+        }
+
+        [Fact]
+        public void DoesNotCallProcessRequest()
+        {
+            _sut.DidRun.ShouldBeFalse();
+        }
+
+        class SampleHandler : BaseHttpHandler
+        {
+            public SampleHandler(IAuthoriser authoriser)
+                : base(authoriser)
+            {
+
+            }
+
+            public override void ProcessRequest(HttpContextBase context)
+            {
+                DidRun = true;
+                context.Response.StatusDescription = "Failed";
+            }
+
+            public bool DidRun;
+        }
+    }
+
+}

--- a/tests/unit-test/Sitecore.Ship.AspNet.Test/Sitecore.Ship.AspNet.Test.csproj
+++ b/tests/unit-test/Sitecore.Ship.AspNet.Test/Sitecore.Ship.AspNet.Test.csproj
@@ -84,6 +84,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BaseHttpHandlerUnauthorisedTests.cs" />
     <Compile Include="AboutCommandBehaviour.cs" />
     <Compile Include="CouplingTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -98,6 +99,10 @@
     <ProjectReference Include="..\..\..\src\Sitecore.Ship.AspNet\Sitecore.Ship.AspNet.csproj">
       <Project>{d8d5e56c-6e0a-4a70-aa85-e0f6ddd97b38}</Project>
       <Name>Sitecore.Ship.AspNet</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\Sitecore.Ship.Core\Sitecore.Ship.Core.csproj">
+      <Project>{F9CC137C-E000-4D1E-9997-B8E3D20F7E36}</Project>
+      <Name>Sitecore.Ship.Core</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\TestUtils\TestUtils.csproj">
       <Project>{6121509c-0554-4fd7-974b-97a81b9df0f3}</Project>


### PR DESCRIPTION
This PR fixes the root cause of https://github.com/kevinobee/Sitecore.Ship/issues/53

The issue was that, when IP authorisation failed, `BaseHttpHandler` was setting the status code but still continuing to call `ProcessRequest`. The reports that it only "worked" on the "/about" endpoint were misguided - it was only apparent on that endpoint because the handler never tried to change the status code, so it remained 401.

This PR includes a fix and unit tests that test for the issue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kevinobee/sitecore.ship/62)

<!-- Reviewable:end -->
