### PR TITLE
generic API url (/services) conflicts with other modules 

### DIFF
--- a/src/Sitecore.Ship.AspNet/content/App_Config/Include/ship.config
+++ b/src/Sitecore.Ship.AspNet/content/App_Config/Include/ship.config
@@ -2,7 +2,7 @@
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:set="http://www.sitecore.net/xmlconfig/set/">
   <sitecore>
     <settings>
-      <setting name="IgnoreUrlPrefixes" set:value="/services/|/sitecore/default.aspx|/trace.axd|/webresource.axd|/sitecore/shell/Controls/Rich Text Editor/Telerik.Web.UI.DialogHandler.aspx|/sitecore/shell/applications/content manager/telerik.web.ui.dialoghandler.aspx|/sitecore/shell/Controls/Rich Text Editor/Telerik.Web.UI.SpellCheckHandler.axd|/Telerik.Web.UI.WebResource.axd|/sitecore/admin/upgrade/|/layouts/testing" />
+      <setting name="IgnoreUrlPrefixes" set:value="/services/publish|/services/package|/services/about|/sitecore/default.aspx|/trace.axd|/webresource.axd|/sitecore/shell/Controls/Rich Text Editor/Telerik.Web.UI.DialogHandler.aspx|/sitecore/shell/applications/content manager/telerik.web.ui.dialoghandler.aspx|/sitecore/shell/Controls/Rich Text Editor/Telerik.Web.UI.SpellCheckHandler.axd|/Telerik.Web.UI.WebResource.axd|/sitecore/admin/upgrade/|/layouts/testing" />
     </settings>
   </sitecore>
 </configuration>

--- a/src/Sitecore.Ship/content/App_Config/Include/ship.config
+++ b/src/Sitecore.Ship/content/App_Config/Include/ship.config
@@ -2,7 +2,7 @@
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:set="http://www.sitecore.net/xmlconfig/set/">
   <sitecore>
     <settings>
-      <setting name="IgnoreUrlPrefixes" set:value="/services/|/sitecore/default.aspx|/trace.axd|/webresource.axd|/sitecore/shell/Controls/Rich Text Editor/Telerik.Web.UI.DialogHandler.aspx|/sitecore/shell/applications/content manager/telerik.web.ui.dialoghandler.aspx|/sitecore/shell/Controls/Rich Text Editor/Telerik.Web.UI.SpellCheckHandler.axd|/Telerik.Web.UI.WebResource.axd|/sitecore/admin/upgrade/|/layouts/testing" />
+      <setting name="IgnoreUrlPrefixes" set:value="/services/publish|/services/package|/services/about|/sitecore/default.aspx|/trace.axd|/webresource.axd|/sitecore/shell/Controls/Rich Text Editor/Telerik.Web.UI.DialogHandler.aspx|/sitecore/shell/applications/content manager/telerik.web.ui.dialoghandler.aspx|/sitecore/shell/Controls/Rich Text Editor/Telerik.Web.UI.SpellCheckHandler.axd|/Telerik.Web.UI.WebResource.axd|/sitecore/admin/upgrade/|/layouts/testing" />
     </settings>
   </sitecore>
 </configuration>


### PR DESCRIPTION
/services API endpoint is not compatible with Sitecore Taxonomy manager from marketplace:

 https://marketplace.sitecore.net/en/Modules/T/Taxonomy_Manager.aspx

![image](https://cloud.githubusercontent.com/assets/1175110/18533508/551c7b18-7ab1-11e6-92f4-9a82ac56ab68.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kevinobee/sitecore.ship/65)

<!-- Reviewable:end -->
