### PR TITLE
Feature/sitecore82

### DIFF
--- a/lib/Readme.md
+++ b/lib/Readme.md
@@ -6,6 +6,7 @@ The following files need to be placed in the folder:
 * Sitecore.Logging.dll
 * Sitecore.Update.dll
 * Sitecore.Zip.dll
+* System.Web.Helpers.dll
 
 These files should be from a 8.x solution.
 

--- a/src/Sitecore.Ship.AspNet/Sitecore.Ship.AspNet.csproj
+++ b/src/Sitecore.Ship.AspNet/Sitecore.Ship.AspNet.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.Ship.AspNet</RootNamespace>
     <AssemblyName>Sitecore.Ship.AspNet</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -37,8 +37,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
+    <Reference Include="System.Web.Helpers">
+      <HintPath>..\..\lib\System.Web.Helpers.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Sitecore.Ship.AspNet/app.config
+++ b/src/Sitecore.Ship.AspNet/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/src/Sitecore.Ship.Core/Sitecore.Ship.Core.csproj
+++ b/src/Sitecore.Ship.Core/Sitecore.Ship.Core.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.Ship.Core</RootNamespace>
     <AssemblyName>Sitecore.Ship.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Sitecore.Ship.Infrastructure/Extensions/PackageInstallationInfoExtensions.cs
+++ b/src/Sitecore.Ship.Infrastructure/Extensions/PackageInstallationInfoExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+using Sitecore.Update;
+
+namespace Sitecore.Ship.Infrastructure.Extensions
+{
+    public static class PackageInstallationInfoExtensions
+    {
+        public static void SetProcessingMode(this PackageInstallationInfo info)
+        {
+            var prop = info.GetType().GetProperty("ProcessingMode", BindingFlags.Public | BindingFlags.Instance);
+            if (prop == null || !prop.CanWrite)
+            {
+                //Pre Sitecore 8.2 Update 2 Versions have no such property
+                return;
+            }
+
+            // ProcessingMode.All = 2147483647
+            prop.SetValue(info, 2147483647);
+        }
+    }
+}

--- a/src/Sitecore.Ship.Infrastructure/Sitecore.Ship.Infrastructure.csproj
+++ b/src/Sitecore.Ship.Infrastructure/Sitecore.Ship.Infrastructure.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.Ship.Infrastructure</RootNamespace>
     <AssemblyName>Sitecore.Ship.Infrastructure</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Sitecore.Ship.Infrastructure/Sitecore.Ship.Infrastructure.csproj
+++ b/src/Sitecore.Ship.Infrastructure/Sitecore.Ship.Infrastructure.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Configuration\PackageInstallationConfigurationProvider.cs" />
     <Compile Include="DataAccess\PackageHistoryRepository.cs" />
     <Compile Include="Diagnostics\Logger.cs" />
+    <Compile Include="Extensions\PackageInstallationInfoExtensions.cs" />
     <Compile Include="Install\PackageManifestReader.cs" />
     <Compile Include="IO\TempPackager.cs" />
     <Compile Include="Web\HttpRequestChecker.cs" />

--- a/src/Sitecore.Ship.Infrastructure/Update/UpdatePackageRunner.cs
+++ b/src/Sitecore.Ship.Infrastructure/Update/UpdatePackageRunner.cs
@@ -7,6 +7,7 @@ using Sitecore.SecurityModel;
 using Sitecore.Ship.Core;
 using Sitecore.Ship.Core.Contracts;
 using Sitecore.Ship.Core.Domain;
+using Sitecore.Ship.Infrastructure.Extensions;
 using Sitecore.Update;
 using Sitecore.Update.Installer;
 using Sitecore.Update.Installer.Exceptions;
@@ -116,16 +117,24 @@ namespace Sitecore.Ship.Infrastructure.Update
         
         private PackageInstallationInfo GetInstallationInfo(string packagePath)
         {
+            if (string.IsNullOrEmpty(packagePath))
+            {
+                throw new Exception("Package is not selected.");
+            }
+
             var info = new PackageInstallationInfo
             {
                 Mode = InstallMode.Install,
                 Action = UpgradeAction.Upgrade,
                 Path = packagePath
             };
-            if (string.IsNullOrEmpty(info.Path))
-            {
-                throw new Exception("Package is not selected.");
-            }
+
+            // this is what we need to do in Sitecore 8.2 Update 2
+            // info.ProcessingMode = ProcessingMode.All
+            // Unfortunately that code is not compilable in previous versions
+            // .SetProcessingMode() assigns that property using reflection
+            info.SetProcessingMode();
+           
             return info;
         }
 

--- a/src/Sitecore.Ship/Sitecore.Ship.csproj
+++ b/src/Sitecore.Ship/Sitecore.Ship.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.Ship</RootNamespace>
     <AssemblyName>Sitecore.Ship</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/src/Sitecore.Ship/app.config
+++ b/src/Sitecore.Ship/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/tests/acceptance-test/Sitecore.Ship.AspNet.Web.Accept.Test/Sitecore.Ship.AspNet.Web.Accept.Test.csproj
+++ b/tests/acceptance-test/Sitecore.Ship.AspNet.Web.Accept.Test/Sitecore.Ship.AspNet.Web.Accept.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -14,7 +14,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.Ship.AspNet.Web.Accept.Test</RootNamespace>
     <AssemblyName>Sitecore.Ship.AspNet.Web.Accept.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />
@@ -55,9 +55,9 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />

--- a/tests/acceptance-test/Sitecore.Ship.AspNet.Web.Accept.Test/Web.config
+++ b/tests/acceptance-test/Sitecore.Ship.AspNet.Web.Accept.Test/Web.config
@@ -1,39 +1,40 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
   <configSections>
-    <section name="packageInstallation" type="Sitecore.Ship.Infrastructure.Configuration.PackageInstallationConfiguration, Sitecore.Ship.Infrastructure" />
+    <section name="packageInstallation" type="Sitecore.Ship.Infrastructure.Configuration.PackageInstallationConfiguration, Sitecore.Ship.Infrastructure"/>
   </configSections>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
-
-
-
-
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.5.2" />
+      </system.Web>
+  -->
   <system.web>
-
-    <compilation debug="true" />
+    <compilation debug="true" targetFramework="4.5.2"/>
     <httpHandlers>
-      <add verb="*" type="Sitecore.Ship.AspNet.SitecoreShipHttpHandler, Sitecore.Ship.AspNet" path="services/*" />
+      <add verb="*" type="Sitecore.Ship.AspNet.SitecoreShipHttpHandler, Sitecore.Ship.AspNet" path="services/*"/>
     </httpHandlers>
   </system.web>
-
-  <packageInstallation enabled="true" allowRemote="false" allowPackageStreaming="false" recordInstallationHistory="false" />
+  <packageInstallation enabled="true" allowRemote="false" allowPackageStreaming="false" recordInstallationHistory="false"/>
   <system.webServer>
-    <modules runAllManagedModulesForAllRequests="true" />
-    <validation validateIntegratedModeConfiguration="false" />
+    <modules runAllManagedModulesForAllRequests="true"/>
+    <validation validateIntegratedModeConfiguration="false"/>
     <handlers>
-      <remove name="Sitecore.Ship" />
-      <add name="Sitecore.Ship" verb="*" type="Sitecore.Ship.AspNet.SitecoreShipHttpHandler, Sitecore.Ship.AspNet" path="services/*" />
+      <remove name="Sitecore.Ship"/>
+      <add name="Sitecore.Ship" verb="*" type="Sitecore.Ship.AspNet.SitecoreShipHttpHandler, Sitecore.Ship.AspNet" path="services/*"/>
     </handlers>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/intg-test/Sitecore.Ship.Infrastructure.Intg.Test/App.config
+++ b/tests/intg-test/Sitecore.Ship.Infrastructure.Intg.Test/App.config
@@ -1,12 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="packageInstallation" type="Sitecore.Ship.Infrastructure.Configuration.PackageInstallationConfiguration, Sitecore.Ship.Infrastructure" />
+    <section name="packageInstallation" type="Sitecore.Ship.Infrastructure.Configuration.PackageInstallationConfiguration, Sitecore.Ship.Infrastructure"/>
   </configSections>
   <packageInstallation enabled="true" allowRemote="true" allowPackageStreaming="true" recordInstallationHistory="true">
     <Whitelist>
-      <add name="Allowed machine 1" IP="1.2.3.4" />
-      <add name="Allowed machine 2" IP="2.3.4.5" />
+      <add name="Allowed machine 1" IP="1.2.3.4"/>
+      <add name="Allowed machine 2" IP="2.3.4.5"/>
     </Whitelist>
   </packageInstallation>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/tests/intg-test/Sitecore.Ship.Infrastructure.Intg.Test/Extensions/PackageInstallationInfoExtensionsTests.cs
+++ b/tests/intg-test/Sitecore.Ship.Infrastructure.Intg.Test/Extensions/PackageInstallationInfoExtensionsTests.cs
@@ -1,0 +1,30 @@
+﻿using Should;
+using Sitecore.Ship.Infrastructure.Extensions;
+using Sitecore.Update;
+using Xunit;
+
+#if SITECORE822 
+using Sitecore.Update.Utils;
+#endif
+
+
+namespace Sitecore.Ship.Infrastructure.Intg.Test.Extensions
+{
+    public class PackageInstallationInfoExtensionsTests
+    {
+        [Fact]
+        public void SetProcessingMode_sets_Mode_All()
+        {
+            //Arrange
+            var sut = new PackageInstallationInfo();
+
+            //Act
+            sut.SetProcessingMode();
+
+            //Assert
+#if SITECORE822
+            sut.ProcessingMode.ShouldEqual(ProcessingMode.All);
+#endif
+        }
+    }
+}

--- a/tests/intg-test/Sitecore.Ship.Infrastructure.Intg.Test/Sitecore.Ship.Infrastructure.Intg.Test.csproj
+++ b/tests/intg-test/Sitecore.Ship.Infrastructure.Intg.Test/Sitecore.Ship.Infrastructure.Intg.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.Ship.Infrastructure.Intg.Test</RootNamespace>
     <AssemblyName>Sitecore.Ship.Infrastructure.Intg.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/tests/intg-test/Sitecore.Ship.Infrastructure.Intg.Test/Sitecore.Ship.Infrastructure.Intg.Test.csproj
+++ b/tests/intg-test/Sitecore.Ship.Infrastructure.Intg.Test/Sitecore.Ship.Infrastructure.Intg.Test.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -41,6 +41,9 @@
   <ItemGroup>
     <Reference Include="Should">
       <HintPath>..\..\..\packages\Should.1.1.20\lib\Should.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Update">
+      <HintPath>..\..\..\lib\Sitecore.Update.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System" />
@@ -69,6 +72,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\PackageInstallationInfoExtensionsTests.cs" />
     <Compile Include="PackageReaderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/tests/unit-test/Sitecore.Ship.AspNet.Test/Sitecore.Ship.AspNet.Test.csproj
+++ b/tests/unit-test/Sitecore.Ship.AspNet.Test/Sitecore.Ship.AspNet.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.Ship.AspNet.Test</RootNamespace>
     <AssemblyName>Sitecore.Ship.AspNet.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/tests/unit-test/Sitecore.Ship.AspNet.Test/app.config
+++ b/tests/unit-test/Sitecore.Ship.AspNet.Test/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/tests/unit-test/Sitecore.Ship.Core.Test/Sitecore.Ship.Core.Test.csproj
+++ b/tests/unit-test/Sitecore.Ship.Core.Test/Sitecore.Ship.Core.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.Ship.Core.Test</RootNamespace>
     <AssemblyName>Sitecore.Ship.Core.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/tests/unit-test/Sitecore.Ship.Test/Sitecore.Ship.Test.csproj
+++ b/tests/unit-test/Sitecore.Ship.Test/Sitecore.Ship.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.Ship.Test</RootNamespace>
     <AssemblyName>Sitecore.Ship.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/tests/unit-test/Sitecore.Ship.Test/app.config
+++ b/tests/unit-test/Sitecore.Ship.Test/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>


### PR DESCRIPTION
This is fix for Sitecore 8.2 Update 2 breaking API changes.

I made fix portable. Reflection is used to access new API added in Sitecore 8.2 Update 2. 

Another option is to start using #ifdef and with it we have to maintain more complicated configuration and generate 2 sets of binaries.

If you think that now it is good time to start maintaining different Sitecore versions I am happy to help.
That is how it is implemented for one of my projects - https://github.com/dharnitski/Sitecore.Algolia. 
I can add something similar to Ship.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kevinobee/sitecore.ship/69)
<!-- Reviewable:end -->
