### PR TITLE
Fixing typo in package installation whitelist configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Shown below is a fully specified configuration section for Sitecore.Ship:
 
     <packageInstallation enabled="true" allowRemote="true" allowPackageStreaming="true" recordInstallationHistory="true">
       <Whitelist>
-        <add name="local loopback" IP="127.0.01" />
+        <add name="local loopback" IP="127.0.0.1" />
         <add name="Allowed machine 1" IP="10.20.3.4" />
         <add name="Allowed machine 2" IP="10.40.4.5" />
       </Whitelist>


### PR DESCRIPTION
Setting up Ship for use in a CI deployment recently, I copied the config example for whitelisting remote access in the main readme. It took me a while to realise package deployments were being refused because of a missing "." in this example.

Figured I should correct that, to avoid others wasting time debugging as I did...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kevinobee/sitecore.ship/80)
<!-- Reviewable:end -->
